### PR TITLE
添加一个 `oneImageFullFrame` 属性

### DIFF
--- a/PYPhotoBrowser/View/PYPhotosView.h
+++ b/PYPhotoBrowser/View/PYPhotosView.h
@@ -102,6 +102,8 @@ typedef NS_ENUM(NSInteger, PYPhotosViewPageType) { // 分页类型
 @property (nonatomic, assign) NSInteger photosMaxCol;
 /** 当图片上传前，最多上传的张数，默认为9 */
 @property (nonatomic, assign) NSInteger imagesMaxCountWhenWillCompose;
+/** 当图片只有一张时, 图片是否充满photosView, 默认：YES*/
+@property (nonatomic, assign) BOOL oneImageFullFrame;
 
 /** 当屏幕旋转时，是否自动旋转图片 默认为YES */
 @property (nonatomic, assign) BOOL autoRotateImage;

--- a/PYPhotoBrowser/View/PYPhotosView.m
+++ b/PYPhotoBrowser/View/PYPhotosView.m
@@ -79,6 +79,7 @@ static NSInteger _photosViewCount;
     self.autoLayoutWithWeChatSytle = YES;
     self.showDuration = 0.5;
     self.hiddenDuration = 0.5;
+    self.oneImageFullFrame = YES;
 }
 
 + (instancetype)photosView
@@ -451,7 +452,7 @@ static NSInteger _photosViewCount;
         if (count < self.imagesMaxCountWhenWillCompose) count ++;
     }
     // 如果图片为一张，则图片的大小和photosView一致
-    if (count == 1 && !CGSizeEqualToSize(self.bounds.size, CGSizeMake(self.photoMargin, self.photoMargin))) {
+    if (count == 1 && && self.oneImageFullFrame !CGSizeEqualToSize(self.bounds.size, CGSizeMake(self.photoMargin, self.photoMargin))) {
         return self.bounds.size;
     }
     cols = (count >= maxCount) ? maxCount : count;
@@ -477,7 +478,7 @@ static NSInteger _photosViewCount;
         maxCol = 2;
     }
     // 当图片为一张时，图片大小和photosView一致
-    if (self.photos.count == 1) {
+    if (self.photos.count == 1 && self.oneImageFullFrame) {
         PYPhotoView *photoView = self.subviews[0];
         photoView.frame = self.bounds;
         self.contentSize = self.bounds.size;


### PR DESCRIPTION
CoderKo1o：

感谢您的这个 PYPhotoBrowser 库，为我们的工作提供便利。

我为您的库添加一个 `oneImageFullFrame` 属性，默认为`YES`，为`NO`时，单张图片尺寸不拉伸。

 PYPhotosView ，若使用 `PYPhotosViewLayoutTypeLine` 布局，一般是长条形状的，只有一张图片时，很大部分情况下不需要改变布局与PYPhotosView同等大小。

例如这样：

![](https://ws4.sinaimg.cn/large/006tNc79gy1fjr9pwl5rtj30uh0dpk6s.jpg)

所以我添加一个 `oneImageFullFrame` 属性，希望能给您带来帮助。

